### PR TITLE
config standardization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,8 @@ node-core-base: &node-core-base
       run:
         name: Unit tests
         command: yarn test:core
+        environment:
+          LS_METRICS_ENABLED: "false"
     - store_artifacts:
         path: ./coverage/lcov-report
 
@@ -76,6 +78,8 @@ node-plugin-base: &node-plugin-base
     - run:
         name: Unit tests
         command: yarn test:plugins
+        environment:
+          LS_METRICS_ENABLED: "false"
     - store_artifacts:
         path: ./coverage/lcov-report
 

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -18,6 +18,7 @@ class Config {
     const logInjection = coalesce(options.logInjection, platform.env('DD_LOGS_INJECTION'), false)
     const env = coalesce(options.env, platform.env('DD_ENV'))
     const url = coalesce(options.url, platform.env('DD_TRACE_AGENT_URL'), platform.env('DD_TRACE_URL'), null)
+    const lsMetricsEnabled = coalesce(options.lsMetricsEnabled, platform.env('LS_METRICS_ENABLED'), true)
     const metricsUrl = coalesce(options.metricsUrl, platform.env('LIGHTSTEP_URL'), null)
     const hostname = coalesce(
       options.hostname,
@@ -58,6 +59,7 @@ class Config {
     this.logInjection = String(logInjection) === 'true'
     this.env = env
     this.url = url && new URL(url)
+    this.lsMetricsEnabled = String(lsMetricsEnabled) === 'true'
     this.metricsUrl = (metricsUrl && new URL(metricsUrl)) || this.url
     this.hostname = hostname || (this.url && this.url.hostname)
     this.port = String(port || (this.url && this.url.port))

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -43,7 +43,6 @@ class Config {
     const reportHostname = coalesce(options.reportHostname, platform.env('DD_TRACE_REPORT_HOSTNAME'), false)
     const scope = coalesce(options.scope, platform.env('DD_TRACE_SCOPE'))
     const clientToken = coalesce(options.clientToken, platform.env('DD_CLIENT_TOKEN'))
-    const componentName = coalesce(options.componentName, platform.env('LIGHTSTEP_COMPONENT_NAME'), null)
     const tags = {}
 
     tagger.add(tags, platform.env('DD_TAGS'))
@@ -89,7 +88,6 @@ class Config {
     this.reportHostname = String(reportHostname) === 'true'
     this.scope = platform.env('DD_CONTEXT_PROPAGATION') === 'false' ? scopes.NOOP : scope
     this.clientToken = clientToken
-    this.componentName = componentName
     this.logLevel = coalesce(
       options.logLevel,
       platform.env('DD_TRACE_LOG_LEVEL'),

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -19,7 +19,11 @@ class Config {
     const env = coalesce(options.env, platform.env('DD_ENV'))
     const url = coalesce(options.url, platform.env('DD_TRACE_AGENT_URL'), platform.env('DD_TRACE_URL'), null)
     const lsMetricsEnabled = coalesce(options.lsMetricsEnabled, platform.env('LS_METRICS_ENABLED'), true)
-    const metricsUrl = coalesce(options.metricsUrl, platform.env('LIGHTSTEP_URL'), null)
+    const lsMetricsUrl = coalesce(
+      options.lsMetricsUrl,
+      platform.env('LS_METRICS_URL'),
+      'https://ingest.lightstep.com:443/metrics'
+    )
     const hostname = coalesce(
       options.hostname,
       platform.env('DD_AGENT_HOST'),
@@ -60,7 +64,7 @@ class Config {
     this.env = env
     this.url = url && new URL(url)
     this.lsMetricsEnabled = String(lsMetricsEnabled) === 'true'
-    this.metricsUrl = (metricsUrl && new URL(metricsUrl)) || this.url
+    this.lsMetricsUrl = (lsMetricsUrl && new URL(lsMetricsUrl)) || this.url
     this.hostname = hostname || (this.url && this.url.hostname)
     this.port = String(port || (this.url && this.url.port))
     this.flushInterval = flushInterval

--- a/packages/dd-trace/src/platform/node/index.js
+++ b/packages/dd-trace/src/platform/node/index.js
@@ -19,7 +19,8 @@ const exporter = require('./exporter')
 
 const emitter = new EventEmitter()
 
-const useDDMetrics = coalesce(process.env['DD_METRICS_RUNTIME'], false)
+const useLSMetrics = String(coalesce(process.env['LS_METRICS_ENABLED'], true)) !== 'false'
+
 const platform = {
   _config: {},
   name: () => 'nodejs',
@@ -33,7 +34,7 @@ const platform = {
   service,
   request,
   msgpack,
-  metrics: useDDMetrics ? metrics : metricsLightStep,
+  metrics: useLSMetrics ? metricsLightStep : metrics,
   plugins,
   hostname,
   on: emitter.on.bind(emitter),

--- a/packages/dd-trace/src/platform/node/proto.js
+++ b/packages/dd-trace/src/platform/node/proto.js
@@ -36,8 +36,8 @@ class Client {
   }
 
   _accessTokenFromTags (tags) {
-    for (let tag of tags) {
-      if(tag.startsWith('lightstep.access_token:')) return tag.split(':')[1]
+    for (const tag of tags) {
+      if (tag.startsWith('lightstep.access_token:')) return tag.split(':')[1]
     }
     return ''
   }

--- a/packages/dd-trace/src/platform/node/proto.js
+++ b/packages/dd-trace/src/platform/node/proto.js
@@ -16,9 +16,9 @@ class Client {
     options = options || {}
     this._start = now()
     this._lastTime = this._start
-    this._url = options.metricsUrl || new Url(options.hostname)
+    this._url = options.lsMetricsUrl || new Url(options.hostname)
 
-    if (options.metricsUrl) {
+    if (options.lsMetricsUrl) {
       this._host = this._url.hostname
       this._port = this._url.port
       this._path = this._url.pathname

--- a/packages/dd-trace/src/platform/node/proto.js
+++ b/packages/dd-trace/src/platform/node/proto.js
@@ -31,7 +31,7 @@ class Client {
     this._prefix = options.prefix || ''
     this._tags = options.tags || []
     this._accessToken = this._accessTokenFromTags(this._tags)
-    this._componentName = options.service || ''
+    this._service = options.service || ''
     this._points = []
   }
 
@@ -78,7 +78,7 @@ class Client {
       points = this._points.slice()
     }
     this._points = []
-    const report = createProtoReport(points, this._componentName)
+    const report = createProtoReport(points, this._service)
     log.debug('generated machine metrics report in', now() - this._lastTime, 'milliseconds')
     if (!this._skipped) {
       log.debug('skipping initial machine metrics report to be able to calculate delta correctly')
@@ -155,7 +155,7 @@ class Client {
   }
 }
 
-function createProtoReport (points, componentName) {
+function createProtoReport (points, service) {
   const protoPoints = points.map((point) => {
     const protoPoint = new metrics.MetricPoint()
 
@@ -186,7 +186,7 @@ function createProtoReport (points, componentName) {
   const reportProto = new metrics.IngestRequest()
   reportProto.setIdempotencyKey(getRandomKey())
   reportProto.setPointsList(protoPoints)
-  reportProto.setReporter(getReporter(componentName))
+  reportProto.setReporter(getReporter(service))
 
   return reportProto.serializeBinary()
 }
@@ -195,10 +195,10 @@ function getRandomKey (length) {
   return crypto.randomBytes(30).toString('hex')
 }
 
-function getReporter (componentName) {
+function getReporter (service) {
   const reporter = new collector.Reporter()
   reporter.setTagsList([
-    new NewKeyValue('lightstep.component_name', componentName),
+    new NewKeyValue('lightstep.component_name', service),
     new NewKeyValue('lightstep.hostname', os.hostname()),
     new NewKeyValue('lightstep.reporter_platform', 'ls-trace-js'),
     new NewKeyValue('lightstep.reporter_platform_version', process.version)

--- a/packages/dd-trace/src/platform/node/proto.js
+++ b/packages/dd-trace/src/platform/node/proto.js
@@ -31,7 +31,7 @@ class Client {
     this._prefix = options.prefix || ''
     this._tags = options.tags || []
     this._clientToken = options.clientToken || ''
-    this._componentName = options.componentName || ''
+    this._componentName = options.service || ''
     this._points = []
   }
 

--- a/packages/dd-trace/src/platform/node/proto.js
+++ b/packages/dd-trace/src/platform/node/proto.js
@@ -30,9 +30,16 @@ class Client {
 
     this._prefix = options.prefix || ''
     this._tags = options.tags || []
-    this._clientToken = options.clientToken || ''
+    this._accessToken = this._accessTokenFromTags(this._tags)
     this._componentName = options.service || ''
     this._points = []
+  }
+
+  _accessTokenFromTags (tags) {
+    for (let tag of tags) {
+      if(tag.startsWith('lightstep.access_token:')) return tag.split(':')[1]
+    }
+    return ''
   }
 
   gauge (name, value, tags) {
@@ -100,7 +107,7 @@ class Client {
         Accept: 'application/octet-stream',
         'Content-Length': buffer.byteLength,
         'Content-Type': 'application/octet-stream',
-        'Lightstep-Access-Token': this._clientToken
+        'Lightstep-Access-Token': this._accessToken
       }
     }
     const request = this._url.protocol === 'http:' ? http.request : https.request

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -33,7 +33,7 @@ class Tracer extends BaseTracer {
           platform.validate()
           platform.configure(config)
 
-          if (config.runtimeMetrics) {
+          if (config.lsMetricsEnabled || config.runtimeMetrics) {
             platform.metrics().start()
           }
 

--- a/testing/test.js
+++ b/testing/test.js
@@ -5,11 +5,7 @@ const tracer = require('../packages/dd-trace').init({
   experimental: {
     b3: true
   },
-  clientToken: 'YOUR_TOKEN',
-  plugins: true,
-  runtimeMetrics: true,
-  reportingInterval: 30 * 1000,
-  componentName: 'ls-trace-js-testing',
+  service: 'ls-trace-js-testing',
   tags: 'lightstep.service_name:ls-trace-js-testing,lightstep.access_token:YOUR_TOKEN',
   url: 'TRACE_URL',
   metricsUrl: 'METRICS_URL',


### PR DESCRIPTION
This PR standardizes configuration of RCA metrics between JS and other implementations. A brief summary of the changes is as follows:

- Use `LS_METRICS_ENABLED` instead of `DD_RUNTIME_METRICS_ENABLED`
- Use `LS_METRICS_URL` to configure the metrics endpoint
- Use `DD_SERVICE_NAME` for the lightstep component
- Get the access token from the global tags rather than `DD_CLIENT_TOKEN`.

cc: @obecny
