### PR TITLE
Use service from global tags

### DIFF
--- a/packages/dd-trace/src/platform/node/proto.js
+++ b/packages/dd-trace/src/platform/node/proto.js
@@ -30,14 +30,14 @@ class Client {
 
     this._prefix = options.prefix || ''
     this._tags = options.tags || []
-    this._accessToken = this._accessTokenFromTags(this._tags)
-    this._service = options.service || ''
+    this._accessToken = this._valueFromTags('lightstep.access_token', this._tags)
+    this._service = this._valueFromTags('lightstep.service_name', this._tags)
     this._points = []
   }
 
-  _accessTokenFromTags (tags) {
+  _valueFromTags (key, tags) {
     for (const tag of tags) {
-      if (tag.startsWith('lightstep.access_token:')) return tag.split(':')[1]
+      if (tag.startsWith(`${key}:`)) return tag.split(':')[1]
     }
     return ''
   }

--- a/testing/test.js
+++ b/testing/test.js
@@ -5,7 +5,6 @@ const tracer = require('../packages/dd-trace').init({
   experimental: {
     b3: true
   },
-  service: 'ls-trace-js-testing',
   tags: 'lightstep.service_name:ls-trace-js-testing,lightstep.access_token:YOUR_TOKEN',
   url: 'TRACE_URL',
   metricsUrl: 'METRICS_URL',


### PR DESCRIPTION
This PR updates ls-trace to extract the service from the `lightstep.service_name` tag.