### PR TITLE
trim the trace ID to the LSB when reporting

### DIFF
--- a/packages/dd-trace/src/encode.js
+++ b/packages/dd-trace/src/encode.js
@@ -10,10 +10,10 @@ module.exports = data => {
   codec = codec || msgpack.createCodec({ int64: true })
 
   data = data.map(span => {
-    let truncated_id = span.trace_id.toString()
-    truncated_id = truncated_id.substring(truncated_id.length - 16)
+    let truncatedId = span.trace_id.toString()
+    truncatedId = truncatedId.substring(truncatedId.length - 16)
     return Object.assign({}, span, {
-      trace_id: new Uint64BE(id(truncated_id, 16).toBuffer()),
+      trace_id: new Uint64BE(id(truncatedId, 16).toBuffer()),
       span_id: new Uint64BE(span.span_id.toBuffer()),
       parent_id: new Uint64BE(span.parent_id.toBuffer()),
       start: new Int64BE(span.start),

--- a/packages/dd-trace/src/encode.js
+++ b/packages/dd-trace/src/encode.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const id = require('./id')
 const msgpack = require('msgpack-lite')
 const { Int64BE, Uint64BE } = require('int64-buffer') // TODO: remove dependency
 
@@ -9,8 +10,10 @@ module.exports = data => {
   codec = codec || msgpack.createCodec({ int64: true })
 
   data = data.map(span => {
+    let truncated_id = span.trace_id.toString()
+    truncated_id = truncated_id.substring(truncated_id.length - 16)
     return Object.assign({}, span, {
-      trace_id: new Uint64BE(span.trace_id.toBuffer()),
+      trace_id: new Uint64BE(id(truncated_id, 16).toBuffer()),
       span_id: new Uint64BE(span.span_id.toBuffer()),
       parent_id: new Uint64BE(span.parent_id.toBuffer()),
       start: new Int64BE(span.start),


### PR DESCRIPTION
This change ensures we only send the LSB to LightStep ingest

Signed-off-by: Alex Boten <aboten@lightstep.com>