### PR TITLE
chore: updating metrics to send seconds instead of nanoseconds

### DIFF
--- a/packages/dd-trace/src/platform/node/metrics_lightstep.js
+++ b/packages/dd-trace/src/platform/node/metrics_lightstep.js
@@ -9,6 +9,7 @@ const Histogram = require('../../histogram')
 const si = require('systeminformation')
 
 const MICROSECOND = 1 / 1e6
+const NANOSECOND = 1 / 1e9
 let nativeMetrics = null
 
 let metrics
@@ -368,10 +369,10 @@ function captureNativeMetrics () {
 function histogram (name, stats, tags) {
   tags = [].concat(tags || [])
 
-  client.gauge(`${name}.min`, stats.min, tags)
-  client.gauge(`${name}.max`, stats.max, tags)
-  client.increment(`${name}.sum`, stats.sum, tags)
-  client.increment(`${name}.total`, stats.sum, tags)
-  client.gauge(`${name}.avg`, stats.avg, tags)
+  client.gauge(`${name}.min`, stats.min * NANOSECOND, tags)
+  client.gauge(`${name}.max`, stats.max * NANOSECOND, tags)
+  client.increment(`${name}.sum`, stats.sum * NANOSECOND, tags)
+  client.increment(`${name}.total`, stats.sum * NANOSECOND, tags)
+  client.gauge(`${name}.avg`, stats.avg * NANOSECOND, tags)
   client.increment(`${name}.count`, stats.count, tags)
 }

--- a/packages/dd-trace/test/platform/node/index_lightstep.spec.js
+++ b/packages/dd-trace/test/platform/node/index_lightstep.spec.js
@@ -553,7 +553,7 @@ describe('Platform', () => {
           metrics.apply(platform).histogram('test', 3)
 
           clock.tick(10000)
-          const NANOSECOND = 1/1e9
+          const NANOSECOND = 1 / 1e9
 
           expect(client.gauge).to.have.been.calledWith('test.max', 3 * NANOSECOND)
           expect(client.gauge).to.have.been.calledWith('test.min', 1 * NANOSECOND)

--- a/packages/dd-trace/test/platform/node/index_lightstep.spec.js
+++ b/packages/dd-trace/test/platform/node/index_lightstep.spec.js
@@ -553,12 +553,13 @@ describe('Platform', () => {
           metrics.apply(platform).histogram('test', 3)
 
           clock.tick(10000)
+          const NANOSECOND = 1/1e9
 
-          expect(client.gauge).to.have.been.calledWith('test.max', 3)
-          expect(client.gauge).to.have.been.calledWith('test.min', 1)
-          expect(client.increment).to.have.been.calledWith('test.sum', 6)
-          expect(client.increment).to.have.been.calledWith('test.total', 6)
-          expect(client.gauge).to.have.been.calledWith('test.avg', 2)
+          expect(client.gauge).to.have.been.calledWith('test.max', 3 * NANOSECOND)
+          expect(client.gauge).to.have.been.calledWith('test.min', 1 * NANOSECOND)
+          expect(client.increment).to.have.been.calledWith('test.sum', 6 * NANOSECOND)
+          expect(client.increment).to.have.been.calledWith('test.total', 6 * NANOSECOND)
+          expect(client.gauge).to.have.been.calledWith('test.avg', 2 * NANOSECOND)
           expect(client.increment).to.have.been.calledWith('test.count', 3)
         })
       })


### PR DESCRIPTION
converting nanoseconds to seconds in runtime metrics