### PR TITLE
do not trace metrics url

### DIFF
--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -250,6 +250,7 @@ function getStatusValidator (config) {
 
 function getFilter (tracer, config) {
   const blacklist = tracer._url ? [`${tracer._url.href}/v0.4/traces`] : []
+  if (tracer._lsMetricsUrl) blacklist.push(tracer._lsMetricsUrl.href)
 
   config = Object.assign({}, config, {
     blacklist: blacklist.concat(config.blacklist || [])

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -41,6 +41,7 @@ class DatadogTracer extends Tracer {
     this._exporter = new Exporter(config, this._prioritySampler)
     this._processor = new SpanProcessor(this._exporter, this._prioritySampler)
     this._url = this._exporter._url
+    this._lsMetricsUrl = config.lsMetricsUrl
     this._sampler = new Sampler(config.sampleRate)
     this._peers = config.experimental.peers
     this._propagators = {

--- a/testing/test.js
+++ b/testing/test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const express = require('express');
 const tracer = require('../packages/dd-trace').init({
   experimental: {
     b3: true
@@ -10,6 +9,7 @@ const tracer = require('../packages/dd-trace').init({
   metricsUrl: 'METRICS_URL',
 });
 
+const express = require('express');
 const app = express();
 
 setInterval(() => {


### PR DESCRIPTION
This updates ls-trace to avoid tracing posts the metrics URL. It also updates the example to exercise this code path.