### PR TITLE
separate ls metrics

### DIFF
--- a/packages/dd-trace/src/platform/node/index.js
+++ b/packages/dd-trace/src/platform/node/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const coalesce = require('koalas')
 const EventEmitter = require('events')
 const crypto = require('./crypto')
 const now = require('./now')
@@ -10,7 +9,7 @@ const service = require('./service')
 const request = require('./request')
 const msgpack = require('./msgpack')
 const metrics = require('./metrics')
-const metricsLightStep = require('./metrics_lightstep')
+const lsMetrics = require('./metrics_lightstep')
 const plugins = require('../../plugins')
 const hostname = require('./hostname')
 const Loader = require('./loader')
@@ -18,8 +17,6 @@ const Scope = require('../../scope/async_hooks')
 const exporter = require('./exporter')
 
 const emitter = new EventEmitter()
-
-const useLSMetrics = String(coalesce(process.env['LS_METRICS_ENABLED'], true)) !== 'false'
 
 const platform = {
   _config: {},
@@ -34,7 +31,8 @@ const platform = {
   service,
   request,
   msgpack,
-  metrics: useLSMetrics ? metricsLightStep : metrics,
+  metrics,
+  lsMetrics,
   plugins,
   hostname,
   on: emitter.on.bind(emitter),

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -33,8 +33,12 @@ class Tracer extends BaseTracer {
           platform.validate()
           platform.configure(config)
 
-          if (config.lsMetricsEnabled || config.runtimeMetrics) {
+          if (config.runtimeMetrics) {
             platform.metrics().start()
+          }
+
+          if (platform.name() === 'nodejs' && config.lsMetricsEnabled) {
+            platform.lsMetrics().start()
           }
 
           if (config.analytics) {


### PR DESCRIPTION
Previously the newly introduced ls metrics system replaced the metrics system used by dd-trace. dd-trace uses this system to record metrics about the tracing client itself, which leads to unexpected metrics being recorded and reported. This PR solves this problem by separating the two metrics systems.

cc: @obecny