### PR TITLE
Testing tedious limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "require-in-the-middle": "^2.2.2",
     "semver": "^5.5.0",
     "shimmer": "^1.2.0",
-    "systeminformation": "^4.22.5",
+    "systeminformation": "^5.6.22",
     "tar": "^4.4.8",
     "url-parse": "^1.4.3",
     "whatwg-fetch": "^3.0.0"
@@ -87,7 +87,7 @@
   "devDependencies": {
     "@babel/core": "^7.6.4",
     "@babel/preset-env": "^7.6.3",
-    "axios": "^0.18.0",
+    "axios": "^0.21.1",
     "babel-loader": "^8.0.6",
     "benchmark": "^2.1.4",
     "body-parser": "^1.18.2",

--- a/packages/datadog-plugin-tedious/src/index.js
+++ b/packages/datadog-plugin-tedious/src/index.js
@@ -85,7 +85,7 @@ function addProcIdTags (span, request) {
 module.exports = [
   {
     name: 'tedious',
-    versions: [ '>=1.0.0' ],
+    versions: [ '9.2.3' ],
     patch (tedious, tracer, config) {
       this.wrap(tedious.Connection.prototype, 'makeRequest', createWrapMakeRequest(tracer, config))
 


### PR DESCRIPTION
This is a spin-off of https://github.com/lightstep/ls-trace-js/pull/27

The build there is breaking for unrelated changes (it started to fail in Jan 2021).

From my investigation it seems we were fine with Tedious up to version 9.2.3 (https://app.circleci.com/pipelines/github/lightstep/ls-trace-js/441/workflows/8063a754-795a-456f-b198-7225588a9964/jobs/25879) but then version 11.0.1 broke it (https://app.circleci.com/pipelines/github/lightstep/ls-trace-js/442/workflows/4556edc7-3195-4beb-8c2b-0a5f77182349/jobs/25926/steps)